### PR TITLE
Add some CF standard names

### DIFF
--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -268,17 +268,17 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
         downwellingSpectralFlux, downwellingFlux = calculateDownwellingSpectralFlux(wvl_lgr, spectrum, delta)
 
         # Add data from hyperspectral_calibration.nco
-        netCDFHandler.createVariable("wvl_dlt", 'f8', ("wvl_lgr",))[:] = delta
+        netCDFHandler.createVariable("wvl_dlt", 'f8', ("wavelength",))[:] = delta
         setattr(netCDFHandler.variables['wvl_dlt'], 'units', 'meter')
         setattr(netCDFHandler.variables['wvl_dlt'], 'notes',"Bandwidth, also called dispersion, is between 0.455-0.495 nm across all channels. Values computed as differences between midpoints of adjacent band-centers.")
         setattr(netCDFHandler.variables['wvl_dlt'], 'long_name', "Bandwidth of environmental sensor")
 
-        netCDFHandler.createVariable("flx_sns", "f4", ("wvl_lgr",))[:] = np.array(FLX_SNS) * 1e-6
+        netCDFHandler.createVariable("flx_sns", "f4", ("wavelength",))[:] = np.array(FLX_SNS) * 1e-6
         setattr(netCDFHandler.variables['flx_sns'],'units', 'watt meter-2 count-1')
         setattr(netCDFHandler.variables['flx_sns'],'long_name','Flux sensitivity of each band (irradiance per count)')
         setattr(netCDFHandler.variables['flx_sns'], 'provenance', "EnvironmentalLogger calibration information from file S05673_08062015.IrradCal provided by TinoDornbusch and discussed here: https://github.com/terraref/reference-data/issues/30#issuecomment-217518434")
 
-        netCDFHandler.createVariable("flx_spc_dwn", 'f4', ('time','wvl_lgr'))[:,:] = downwellingSpectralFlux
+        netCDFHandler.createVariable("flx_spc_dwn", 'f4', ('time','wavelength'))[:,:] = downwellingSpectralFlux
         setattr(netCDFHandler.variables['flx_spc_dwn'],'units', 'watt meter-2 meter-1')
         setattr(netCDFHandler.variables['flx_spc_dwn'], 'long_name', 'Downwelling Spectral Irradiance')
         setattr(netCDFHandler.variables['flx_spc_dwn'], 'standard_name', 'downwelling_spectral_spherical_irradiance_in_air')

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -218,6 +218,8 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
             valueVariable[:]    = value
             rawValueVariable[:] = rawValue
             setattr(valueVariable, "units", unit[0])
+            if data in _CF_STANDARDS:
+                setattr(valueVariable, "standard_name", _CF_STANDARDS[data])
 
         wvl_lgr, spectrum, maxFixedIntensity = handleSpectrometer(loggerReadings) #writing the data from spectrometer
 

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -90,6 +90,11 @@ _UNIT_DICTIONARY = {u'm': {"original":"meter", "SI":"meter", "power":1},
                     u'us': {"original":"microsecond", "SI":"second", "power":1e-6},
                     u'ppm': {"original":"pascal meter-2", "SI":"pascal meter-2", "power":1}, 
                     '': ''}
+
+_CF_STANDARDS    = {u'precipitation' : "liquid_water_equivalent_precipitation_rate",
+                    u'airPressure'   : "air_pressure"
+                    u'relHumidity'   : "relative_humidity"}
+
 _NAMES = {'sensor par': 'Sensor Photosynthetically Active Radiation'}
 
 _UNIX_BASETIME = date(year=1970, month=1, day=1)
@@ -216,9 +221,9 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
 
         wvl_lgr, spectrum, maxFixedIntensity = handleSpectrometer(loggerReadings) #writing the data from spectrometer
 
-        netCDFHandler.createDimension("wvl_lgr", len(wvl_lgr))
-        wavelengthVariable = spectrometerGroup.createVariable("wvl_lgr", "f4", ("wvl_lgr",))
-        spectrumVariable   = spectrometerGroup.createVariable("spectrum", "f4", ("time", "wvl_lgr"))
+        netCDFHandler.createDimension("wavelength", len(wvl_lgr))
+        wavelengthVariable = spectrometerGroup.createVariable("wavelength", "f4", ("wavelength",))
+        spectrumVariable   = spectrometerGroup.createVariable("spectrum", "f4", ("time", "wavelength"))
         intensityVariable  = spectrometerGroup.createVariable("maxFixedIntensity", "f4", ("time",))
 
         #TODO
@@ -276,11 +281,13 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
         netCDFHandler.createVariable("flx_spc_dwn", 'f4', ('time','wvl_lgr'))[:,:] = downwellingSpectralFlux
         setattr(netCDFHandler.variables['flx_spc_dwn'],'units', 'watt meter-2 meter-1')
         setattr(netCDFHandler.variables['flx_spc_dwn'], 'long_name', 'Downwelling Spectral Irradiance')
+        setattr(netCDFHandler.variables['flx_spc_dwn'], 'standard_name', 'downwelling_spectral_spherical_irradiance_in_air')
 
         # Downwelling Flux = summation of (delta lambda(_wvl_dlt) * downwellingSpectralFlux)
         netCDFHandler.createVariable("flx_dwn", 'f4')[...] = downwellingFlux
         setattr(netCDFHandler.variables["flx_dwn"], "units", "watt meter-2")
         setattr(netCDFHandler.variables['flx_dwn'], 'long_name', 'Downwelling Irradiance')
+        setattr(netCDFHandler.variables['flx_dwn'], 'standard_name', 'downwelling_spherical_irradiance_in_air')
 
         # #Other Constants used in calculation
         # #Integration Time

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -262,6 +262,8 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
                 sensorValueVariable[:]    = sensorValue
                 sensorRawValueVariable[:] = sensorRaw
                 setattr(sensorValueVariable, "units", sensorUnit[0])
+                if renameTheValue(data) in _CF_STANDARDS:
+                    setattr(sensorValueVariable, "standard_name", _CF_STANDARDS[renameTheValue(data)])
 
         wvl_ntf  = [np.average([wvl_lgr[i], wvl_lgr[i+1]]) for i in range(len(wvl_lgr)-1)]
         delta    = [wvl_ntf[i+1] - wvl_ntf[i] for i in range(len(wvl_ntf) - 1)]

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -93,7 +93,8 @@ _UNIT_DICTIONARY = {u'm': {"original":"meter", "SI":"meter", "power":1},
 
 _CF_STANDARDS    = {u'precipitation' : "liquid_water_equivalent_precipitation_rate",
                     u'airPressure'   : "air_pressure",
-                    u'relHumidity'   : "relative_humidity"}
+                    u'relHumidity'   : "relative_humidity",
+                    u"windDirection" : "wind_to_direction"}
 
 _NAMES = {'sensor par': 'Sensor Photosynthetically Active Radiation'}
 
@@ -223,9 +224,9 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
 
         wvl_lgr, spectrum, maxFixedIntensity = handleSpectrometer(loggerReadings) #writing the data from spectrometer
 
-        netCDFHandler.createDimension("wavelength", len(wvl_lgr))
-        wavelengthVariable = spectrometerGroup.createVariable("wavelength", "f4", ("wavelength",))
-        spectrumVariable   = spectrometerGroup.createVariable("spectrum", "f4", ("time", "wavelength"))
+        netCDFHandler.createDimension("wvl_lgr", len(wvl_lgr))
+        wavelengthVariable = spectrometerGroup.createVariable("wavelength", "f4", ("wvl_lgr",))
+        spectrumVariable   = spectrometerGroup.createVariable("spectrum", "f4", ("time", "wvl_lgr"))
         intensityVariable  = spectrometerGroup.createVariable("maxFixedIntensity", "f4", ("time",))
 
         #TODO
@@ -233,6 +234,7 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
         wavelengthVariable[:] = wvl_lgr
         setattr(wavelengthVariable, "units", "meter")
         setattr(wavelengthVariable, "long_name", "wavelengths")
+        setattr(wavelengthVariable, "standard_name", "radiation_wavelength")
         setattr(wavelengthVariable, "notes", "these wavelengths are all the same in different collections from the environmental logger. Ranging from 337.7 to 824 nm.")
         spectrumVariable[:,:] = spectrum
         setattr(spectrumVariable, "units", "placeholder")
@@ -270,17 +272,17 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
         downwellingSpectralFlux, downwellingFlux = calculateDownwellingSpectralFlux(wvl_lgr, spectrum, delta)
 
         # Add data from hyperspectral_calibration.nco
-        netCDFHandler.createVariable("wvl_dlt", 'f8', ("wavelength",))[:] = delta
+        netCDFHandler.createVariable("wvl_dlt", 'f8', ("wvl_lgr",))[:] = delta
         setattr(netCDFHandler.variables['wvl_dlt'], 'units', 'meter')
         setattr(netCDFHandler.variables['wvl_dlt'], 'notes',"Bandwidth, also called dispersion, is between 0.455-0.495 nm across all channels. Values computed as differences between midpoints of adjacent band-centers.")
         setattr(netCDFHandler.variables['wvl_dlt'], 'long_name', "Bandwidth of environmental sensor")
 
-        netCDFHandler.createVariable("flx_sns", "f4", ("wavelength",))[:] = np.array(FLX_SNS) * 1e-6
+        netCDFHandler.createVariable("flx_sns", "f4", ("wvl_lgr",))[:] = np.array(FLX_SNS) * 1e-6
         setattr(netCDFHandler.variables['flx_sns'],'units', 'watt meter-2 count-1')
         setattr(netCDFHandler.variables['flx_sns'],'long_name','Flux sensitivity of each band (irradiance per count)')
         setattr(netCDFHandler.variables['flx_sns'], 'provenance', "EnvironmentalLogger calibration information from file S05673_08062015.IrradCal provided by TinoDornbusch and discussed here: https://github.com/terraref/reference-data/issues/30#issuecomment-217518434")
 
-        netCDFHandler.createVariable("flx_spc_dwn", 'f4', ('time','wavelength'))[:,:] = downwellingSpectralFlux
+        netCDFHandler.createVariable("flx_spc_dwn", 'f4', ('time','wvl_lgr'))[:,:] = downwellingSpectralFlux
         setattr(netCDFHandler.variables['flx_spc_dwn'],'units', 'watt meter-2 meter-1')
         setattr(netCDFHandler.variables['flx_spc_dwn'], 'long_name', 'Downwelling Spectral Irradiance')
         setattr(netCDFHandler.variables['flx_spc_dwn'], 'standard_name', 'downwelling_spectral_spherical_irradiance_in_air')

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -94,7 +94,7 @@ _UNIT_DICTIONARY = {u'm': {"original":"meter", "SI":"meter", "power":1},
 _CF_STANDARDS    = {u'precipitation' : "liquid_water_equivalent_precipitation_rate",
                     u'airPressure'   : "air_pressure",
                     u'relHumidity'   : "relative_humidity",
-                    u"windDirection" : "wind_to_direction"}
+                    u"windDirection" : "wind_from_direction"}
 
 _NAMES = {'sensor par': 'Sensor Photosynthetically Active Radiation'}
 

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -88,7 +88,7 @@ _UNIT_DICTIONARY = {u'm': {"original":"meter", "SI":"meter", "power":1},
                     u'degrees': {"original":"degree", "SI":"degree", "power":1}, 
                     u'?s': {"original":"microsecond", "SI":"second", "power":1e-6}, 
                     u'us': {"original":"microsecond", "SI":"second", "power":1e-6},
-                    u'ppm': {"original":"part per million", "SI":"umol mol-1", "power":1}, 
+                    u'ppm': {"original":"part per million", "SI":"mol mol-1", "power":1e-6}, 
                     '': ''}
 
 _CF_STANDARDS    = {u'precipitation' : "precipitation_flux",

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -92,7 +92,7 @@ _UNIT_DICTIONARY = {u'm': {"original":"meter", "SI":"meter", "power":1},
                     '': ''}
 
 _CF_STANDARDS    = {u'precipitation' : "liquid_water_equivalent_precipitation_rate",
-                    u'airPressure'   : "air_pressure"
+                    u'airPressure'   : "air_pressure",
                     u'relHumidity'   : "relative_humidity"}
 
 _NAMES = {'sensor par': 'Sensor Photosynthetically Active Radiation'}
@@ -212,8 +212,8 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
         spectrometerGroup   = netCDFHandler.groups["spectrometer"]
         for data in loggerReadings[0]["weather_station"]: #writing the data from weather station
             value, unit, rawValue           = getListOfWeatherStationValue(loggerReadings, data)
-            valueVariable, rawValueVariable = weatherStationGroup.createVariable(data,                   "f4", ("time", )),\
-                                            weatherStationGroup.createVariable("".join(("raw_",data)), "f4", ("time", ))
+            valueVariable, rawValueVariable = weatherStationGroup.createVariable(data, "f4", ("time", )),\
+                                              weatherStationGroup.createVariable("".join(("raw_",data)), "f4", ("time", ))
                 
             valueVariable[:]    = value
             rawValueVariable[:] = rawValue

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -88,13 +88,14 @@ _UNIT_DICTIONARY = {u'm': {"original":"meter", "SI":"meter", "power":1},
                     u'degrees': {"original":"degree", "SI":"degree", "power":1}, 
                     u'?s': {"original":"microsecond", "SI":"second", "power":1e-6}, 
                     u'us': {"original":"microsecond", "SI":"second", "power":1e-6},
-                    u'ppm': {"original":"pascal meter-2", "SI":"pascal meter-2", "power":1}, 
+                    u'ppm': {"original":"part per million", "SI":"umol mol-1", "power":1}, 
                     '': ''}
 
-_CF_STANDARDS    = {u'precipitation' : "liquid_water_equivalent_precipitation_rate",
+_CF_STANDARDS    = {u'precipitation' : "precipitation_flux",
                     u'airPressure'   : "air_pressure",
                     u'relHumidity'   : "relative_humidity",
-                    u"windDirection" : "wind_from_direction"}
+                    u"windDirection" : "wind_from_direction",
+                    u"sensor_co2"    : "mole_fraction_of_carbon_dioxide_in_air"}
 
 _NAMES = {'sensor par': 'Sensor Photosynthetically Active Radiation'}
 

--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -225,7 +225,7 @@ def main(JSONArray, outputFileName, wavelength=None, spectrum=None, downwellingS
         wvl_lgr, spectrum, maxFixedIntensity = handleSpectrometer(loggerReadings) #writing the data from spectrometer
 
         netCDFHandler.createDimension("wvl_lgr", len(wvl_lgr))
-        wavelengthVariable = spectrometerGroup.createVariable("wavelength", "f4", ("wvl_lgr",))
+        wavelengthVariable = spectrometerGroup.createVariable("wvl_lgr", "f4", ("wvl_lgr",))
         spectrumVariable   = spectrometerGroup.createVariable("spectrum", "f4", ("time", "wvl_lgr"))
         intensityVariable  = spectrometerGroup.createVariable("maxFixedIntensity", "f4", ("time",))
 


### PR DESCRIPTION
The following variables now have CF standard names:

- airPressure
- flx_dwn
- flx_spc_dwn
- precipitation
- relHumidity
- wavelength
- windDirection

**Help wanted: there are two choices for "windDirection" in CF convention: "wind_to_direction" and "wind_from_direction." Temporarily I use “wind_from_direction."**

Recommend to test with the environmental loggers in October:
```sh
python environmental_logger_json2netcdf.py /projects/arpae/terraref/sites/ua-mac/raw_data/EnvironmentLogger/2016-10-15/2016-10-15_19-56-57_environmentlogger.json ~/rgr
```
