### PR TITLE
Unlink the dependency on geostream

### DIFF
--- a/environmentlogger/environmental_logger_json2netcdf.py
+++ b/environmentlogger/environmental_logger_json2netcdf.py
@@ -75,7 +75,7 @@ import argparse
 from datetime import date, datetime
 from netCDF4  import Dataset
 from environmental_logger_calculation import *
-from environmental_geostream import push_to_geostream
+# from environmental_geostream import push_to_geostream
 
 
 _UNIT_DICTIONARY = {u'm': {"original":"meter", "SI":"meter", "power":1}, 


### PR DESCRIPTION
Now the [environmental_logger_json2netcdf.py] has no dependency on PyClowder (i.e., Geostreaming) since @max moved and fixed these functions to [terra_environmentlogger.py](https://github.com/terraref/extractors-environmental/blob/geostreams-cleanup/environmentlogger/terra_environmentlogger.py), which the json2netcdf.py has no dependency on it.

Also @czender and refer #10 